### PR TITLE
feat:

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 - Context API
 - Tanstack Query
 -> 이외의 라이브러리들도 자유롭게 사용해도 괜찮으나, 위 나열된 기술 스택들은 반드시 모두 사용해야함.
+#### 추가 라이브러리
+- tailwind merge, clsx, cva(class-validator-authority)
+- react-hook-form, zod, @hookform/resolvers
 
 ### 2. 페이지 별 기능
 1. 홈페이지 - SSR(SSG)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.6.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "cookies-next": "^4.1.1",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18",

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,10 +1,35 @@
 import axiosInstance from "@/lib/axiosAPI";
 import { z } from "zod";
 import { SignUpFormSchema } from "@/validators/signUp.validator";
+import { LoginFormSchema } from "@/validators/login.validator";
+import axios from "axios";
 
 export const PostSignUp = async (data: z.infer<typeof SignUpFormSchema>) => {
-  return await axiosInstance.post("/auth/sign-up", {
+  return await axiosInstance.post(
+    "/auth/sign-up",
+    {
+      email: data.email,
+      password: data.password,
+    },
+    { withCredentials: true },
+  );
+};
+
+export const PostLogin = async (data: z.infer<typeof LoginFormSchema>) => {
+  const response = await axios.post("/api/auth", {
     email: data.email,
     password: data.password,
   });
+
+  return response.data;
+};
+
+export const DeleteLogout = async () => {
+  const response = await axios.delete("/api/auth");
+  return response.data;
+};
+
+export const GetIsLogin = async () => {
+  const response = await axios.get("/api/auth");
+  return response.data;
 };

--- a/src/app/(layout)/_components/auth/HeaderAuth.tsx
+++ b/src/app/(layout)/_components/auth/HeaderAuth.tsx
@@ -1,17 +1,39 @@
+"use client";
+
 import Link from "next/link";
+import { useModal } from "@/context/modalContext";
+import { useAuth } from "@/context/auth";
 
 function HeaderAuth() {
+  const { handleIsOpen } = useModal();
+  const { isLogin, logout } = useAuth();
+
+  const baseStyle =
+    "text-[15px] text-gray-800 hover:text-black transition font-medium";
+
+  if (isLogin === null) return null;
+
   return (
     <div className="ml-auto flex gap-x-4 items-center text-[15px]">
-      <Link
-        href={"/sign-up"}
-        className="text-inherit text-gray-800 hover:text-black transition font-medium"
-      >
-        회원가입
-      </Link>
-      <button className="text-inherit text-gray-800 hover:text-black transition font-medium">
-        로그인
-      </button>
+      {!isLogin ? (
+        <>
+          <Link href={"/sign-up"} className={baseStyle}>
+            회원가입
+          </Link>
+          <button className={baseStyle} onClick={(e) => handleIsOpen(e, true)}>
+            로그인
+          </button>
+        </>
+      ) : (
+        <>
+          <Link href={"/cart"} className={baseStyle}>
+            장바구니
+          </Link>
+          <button className={baseStyle} onClick={logout}>
+            로그아웃
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/(layout)/layout.tsx
+++ b/src/app/(layout)/layout.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from "react";
 import MainHeader from "@/app/(layout)/_components/header";
 import Providers from "@/providers";
 import ToastContainer from "@/components/UI/Toast/Organisms/ToastContainer";
+import Modal from "@/components/Pages/Modal";
+import LoginContainer from "@/components/Organisms/LoginContainer";
 
 interface Props {
   children: ReactNode;
@@ -13,6 +15,9 @@ function Layout({ children }: Props) {
       <MainHeader />
       {children}
       <ToastContainer />
+      <Modal>
+        <LoginContainer />
+      </Modal>
     </Providers>
   );
 }

--- a/src/app/(layout)/sign-up/page.tsx
+++ b/src/app/(layout)/sign-up/page.tsx
@@ -6,7 +6,7 @@ import ErrorSpan from "@/components/Atoms/ErrorSpan";
 import useSignUpForm from "@/hooks/SignUpForm";
 
 function SignUp() {
-  const { register, handleSubmit, errors, isPending, OnSubmit } =
+  const { register, handleSubmit, errors, isDisabled, OnSubmit } =
     useSignUpForm();
 
   return (
@@ -21,7 +21,7 @@ function SignUp() {
           <SignUpForm.FormInput.Input
             type="text"
             {...register("email")}
-            disabled={isPending}
+            disabled={isDisabled}
           />
           {errors.email?.message && (
             <ErrorSpan>{errors.email?.message}</ErrorSpan>
@@ -35,7 +35,7 @@ function SignUp() {
           <SignUpForm.FormInput.Input
             type="password"
             {...register("password")}
-            disabled={isPending}
+            disabled={isDisabled}
           />
           {errors.password?.message && (
             <ErrorSpan>{errors.password?.message}</ErrorSpan>
@@ -49,7 +49,7 @@ function SignUp() {
           <SignUpForm.FormInput.Input
             type="password"
             {...register("passwordConfirm")}
-            disabled={isPending}
+            disabled={isDisabled}
           />
           {errors.passwordConfirm?.message && (
             <ErrorSpan>{errors.passwordConfirm?.message}</ErrorSpan>
@@ -57,7 +57,7 @@ function SignUp() {
         </SignUpForm.FormInput>
 
         <div className="mt-2"></div>
-        <SignUpForm.SubmitButton disabled={isPending}>
+        <SignUpForm.SubmitButton type={"button"} disabled={isDisabled}>
           회원가입하기
         </SignUpForm.SubmitButton>
       </SignUpForm>

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -1,0 +1,51 @@
+import axiosInstance from "@/lib/axiosAPI";
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { parse } from "cookie";
+
+interface FetchResponse {
+  success: boolean | null;
+  result: null;
+  error: boolean | null;
+}
+
+export const POST = async (req: Request) => {
+  const { email, password } = await req.json();
+  const response = await axiosInstance.post(
+    "/auth/log-in",
+    { email, password },
+    { withCredentials: true },
+  );
+
+  const token = response.headers["set-cookie"];
+  if (Array.isArray(token) && token.length !== 0) {
+    const cookieString = token[0];
+    const parsedCookies = parse(cookieString);
+    const accessToken = parsedCookies.accessToken;
+
+    if (accessToken) {
+      cookies().set("accessToken", accessToken, { httpOnly: true });
+    }
+  }
+  return NextResponse.json({
+    result: response.data,
+  } as FetchResponse);
+};
+
+export const DELETE = async () => {
+  const response = await axiosInstance.delete("/auth/log-out");
+
+  cookies().delete("accessToken");
+
+  return NextResponse.json({
+    result: response.data,
+  } as FetchResponse);
+};
+
+export const GET = () => {
+  const token = cookies().get("accessToken");
+  console.log("token = ", token?.value);
+  return NextResponse.json({
+    isLogin: !!token,
+  });
+};

--- a/src/components/Organisms/LoginContainer.tsx
+++ b/src/components/Organisms/LoginContainer.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Title } from "@/components/Atoms";
+import LoginForm from "@/components/Organisms/LoginForm";
+import ErrorSpan from "@/components/Atoms/ErrorSpan";
+import useLoginForm from "@/hooks/LoginForm";
+
+function LoginContainer() {
+  const { register, handleSubmit, errors, OnSubmit, isDisabled } =
+    useLoginForm();
+
+  return (
+    <main className="bg-white rounded-md w-full max-w-[400px] px-5 py-8 m-auto">
+      <Title>로그인</Title>
+      <LoginForm onSubmit={handleSubmit((data) => OnSubmit(data))}>
+        <LoginForm.FormInput>
+          <LoginForm.FormInput.Label htmlFor={"email"}>
+            이메일
+          </LoginForm.FormInput.Label>
+          <LoginForm.FormInput.Input
+            type="text"
+            {...register("email")}
+            disabled={isDisabled}
+          />
+          {errors.email?.message && (
+            <ErrorSpan>{errors.email?.message}</ErrorSpan>
+          )}
+        </LoginForm.FormInput>
+
+        <LoginForm.FormInput>
+          <LoginForm.FormInput.Label htmlFor={"password"}>
+            비밀번호
+          </LoginForm.FormInput.Label>
+          <LoginForm.FormInput.Input
+            type="password"
+            {...register("password")}
+            disabled={isDisabled}
+          />
+          {errors.password?.message && (
+            <ErrorSpan>{errors.password?.message}</ErrorSpan>
+          )}
+        </LoginForm.FormInput>
+
+        <LoginForm.SubmitButton type={"submit"} disabled={isDisabled}>
+          로그인하기
+        </LoginForm.SubmitButton>
+      </LoginForm>
+    </main>
+  );
+}
+
+export default LoginContainer;

--- a/src/components/Organisms/LoginForm.tsx
+++ b/src/components/Organisms/LoginForm.tsx
@@ -1,0 +1,23 @@
+import { FormInput } from "@/components/Molecules";
+import Button from "@/components/Atoms/Button";
+import { ComponentProps, ReactNode } from "react";
+
+interface Props extends ComponentProps<"form"> {
+  children: ReactNode;
+}
+
+function LoginForm({ children, ...props }: Props) {
+  return (
+    <form
+      {...props}
+      className="flex flex-col items-center gap-y-8 max-w-sm mx-auto w-full"
+    >
+      {children}
+    </form>
+  );
+}
+
+LoginForm.FormInput = FormInput;
+LoginForm.SubmitButton = Button;
+
+export default LoginForm;

--- a/src/components/Pages/Modal.tsx
+++ b/src/components/Pages/Modal.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { ReactNode } from "react";
+import { useModal } from "@/context/modalContext";
+
+interface Props {
+  children: ReactNode;
+}
+
+function Modal({ children }: Props) {
+  const { isOpen, handleIsOpen } = useModal();
+  return (
+    <>
+      {isOpen && (
+        <div
+          className="bg-black/50 flex h-[100vh] w-[100vw] fixed top-0 left-0 z-20"
+          onClick={(e) => handleIsOpen(e, false)}
+        >
+          {children}
+        </div>
+      )}
+    </>
+  );
+}
+
+export default Modal;

--- a/src/components/Pages/index.ts
+++ b/src/components/Pages/index.ts
@@ -1,3 +1,4 @@
 export { default as ProductsPageContainer } from "./ProductsPageContainer";
 export { default as ProductDetailPage } from "./ProductPage";
 export { default as BrandsPage } from "./BrandsPage";
+export { default as Modal } from "./Modal";

--- a/src/components/UI/Toast/Organisms/ToastContainer.tsx
+++ b/src/components/UI/Toast/Organisms/ToastContainer.tsx
@@ -11,8 +11,7 @@ import Toast from "@/components/UI/Toast/Molecules/Toast";
 
 function ToastContainer() {
   const { toasts } = useToast();
-
-  const toastPosition = `absolute max-h-[100vh] h-auto w-auto flex flex-col gap-5 overflow-hidden bottom-5 right-5`;
+  const toastPosition = `fixed max-h-[100vh] h-auto w-auto z-30 flex flex-col gap-5 overflow-hidden bottom-5 right-5`;
 
   return (
     <section

--- a/src/components/UI/Toast/context/Toast/ToastContext.tsx
+++ b/src/components/UI/Toast/context/Toast/ToastContext.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from "react";
 import { VariantProps } from "class-variance-authority";
-import Toast from "@/components/UI/Toast/Molecules/Toast.tsx";
+import Toast from "@/components/UI/Toast/Molecules/Toast";
 
 type ToastPositionX = "left" | "right";
 type ToastPositionY = "top" | "bottom";

--- a/src/components/UI/Toast/context/Toast/index.ts
+++ b/src/components/UI/Toast/context/Toast/index.ts
@@ -1,1 +1,1 @@
-export { useToast, ToastProvider } from "./ToastContext.tsx";
+export { useToast, ToastProvider } from "./ToastContext";

--- a/src/context/auth/AuthContext.tsx
+++ b/src/context/auth/AuthContext.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { DeleteLogout, GetIsLogin } from "@/api/auth";
+import { usePathname } from "next/navigation";
+
+//1. 만든다.
+interface AuthContext {
+  isLogin: boolean | null;
+  logout: () => void;
+  checkLogin: () => void;
+}
+
+const initialAuth: AuthContext = {
+  isLogin: false,
+  logout: () => {},
+  checkLogin: () => {},
+};
+
+const AuthContext = createContext<AuthContext>(initialAuth);
+
+//2. 사용한다.
+export const useAuth = () => useContext(AuthContext);
+
+//3. 범위를 지정한다.
+export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [isLogin, setIsLogin] = useState<boolean | null>(null);
+  const { data, refetch } = useQuery({
+    queryKey: ["isLogin"],
+    queryFn: GetIsLogin,
+  });
+  const { mutate } = useMutation({
+    mutationFn: DeleteLogout,
+    onSuccess: () => {
+      setIsLogin(false);
+    },
+  });
+  const pathname = usePathname();
+
+  const logout = useCallback(() => {
+    mutate();
+  }, [mutate]);
+
+  const checkLogin = useCallback(async () => {
+    await refetch();
+    setIsLogin(data?.isLogin);
+  }, [data, refetch]);
+
+  useEffect(() => {
+    (async () => {
+      await checkLogin();
+    })();
+  }, [pathname, checkLogin]);
+
+  const value = useMemo(
+    () => ({ isLogin, logout, checkLogin }),
+    [isLogin, logout, checkLogin],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/src/context/auth/index.ts
+++ b/src/context/auth/index.ts
@@ -1,0 +1,1 @@
+export { useAuth, AuthProvider } from "./AuthContext";

--- a/src/context/modalContext/ModalContext.tsx
+++ b/src/context/modalContext/ModalContext.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+interface ModalContext {
+  isOpen: boolean;
+  handleIsOpen: (
+    e: React.MouseEvent<HTMLElement> | null,
+    isOpen: boolean,
+  ) => void;
+}
+
+const initialModal: ModalContext = {
+  isOpen: false,
+  handleIsOpen: () => {},
+};
+
+//1. 만든다.
+const ModalContext = createContext<ModalContext>(initialModal);
+
+//2. 사용한다.
+export const useModal = () => useContext(ModalContext);
+
+//3. 범위를 지정한다.
+export const ModalProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const handleIsOpen = useCallback(
+    (e: React.MouseEvent<HTMLElement> | null, currentIsOpen: boolean) => {
+      if (e !== null) {
+        e.stopPropagation();
+        if (e.currentTarget !== e.target) {
+          return;
+        }
+      }
+
+      setIsOpen(currentIsOpen);
+    },
+    [],
+  );
+
+  const value: ModalContext = useMemo(
+    () => ({
+      isOpen,
+      handleIsOpen,
+    }),
+    [isOpen, handleIsOpen],
+  );
+
+  return (
+    <ModalContext.Provider value={value}>{children}</ModalContext.Provider>
+  );
+};

--- a/src/context/modalContext/index.ts
+++ b/src/context/modalContext/index.ts
@@ -1,0 +1,1 @@
+export { useModal, ModalProvider } from "./ModalContext";

--- a/src/hooks/DisableState/index.ts
+++ b/src/hooks/DisableState/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./useDisable";

--- a/src/hooks/DisableState/useDisable.ts
+++ b/src/hooks/DisableState/useDisable.ts
@@ -1,0 +1,15 @@
+import { useCallback, useState } from "react";
+
+type ReturnType = [boolean, (pending: boolean) => void];
+
+const useDisable = (): ReturnType => {
+  const [state, setState] = useState<boolean>(false);
+
+  const handleDisable = useCallback((pending: boolean) => {
+    setState(pending);
+  }, []);
+
+  return [state, handleDisable];
+};
+
+export default useDisable;

--- a/src/hooks/LoginForm/index.ts
+++ b/src/hooks/LoginForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./useLoginForm";

--- a/src/hooks/LoginForm/useLoginForm.ts
+++ b/src/hooks/LoginForm/useLoginForm.ts
@@ -2,51 +2,56 @@
 
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { SignUpFormSchema } from "@/validators/signUp.validator";
+import { LoginFormSchema } from "@/validators/login.validator";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback } from "react";
+import { PostLogin } from "@/api/auth";
 import { useMutation } from "@tanstack/react-query";
-import { PostSignUp } from "@/api/auth";
 import { useToast } from "@/components/UI/Toast/context/Toast";
-import { useRouter } from "next/navigation";
 import useDisable from "@/hooks/DisableState";
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useModal } from "@/context/modalContext";
+import { useAuth } from "@/context/auth";
 
-const useSignUpForm = () => {
-  const { mutate, isPending } = useMutation({ mutationFn: PostSignUp });
+const useLoginForm = () => {
+  const { mutate } = useMutation({ mutationFn: PostLogin });
   const { toast } = useToast();
   const [isDisabled, handleToggleDisable] = useDisable();
+  const { handleIsOpen } = useModal();
+  const { checkLogin } = useAuth();
   const router = useRouter();
 
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<z.infer<typeof SignUpFormSchema>>({
-    resolver: zodResolver(SignUpFormSchema),
+  } = useForm<z.infer<typeof LoginFormSchema>>({
+    resolver: zodResolver(LoginFormSchema),
     defaultValues: {
       email: "",
       password: "",
-      passwordConfirm: "",
     },
   });
 
   const OnSubmit = useCallback(
-    (data: z.infer<typeof SignUpFormSchema>) => {
+    (data: z.infer<typeof LoginFormSchema>) => {
       handleToggleDisable(true);
       mutate(data, {
-        onSuccess: () => {
+        onSuccess: async () => {
           toast({
-            title: "회원가입에 성공했습니다.",
+            title: "로그인에 성공했습니다.",
             variant: "success",
             size: "lg",
             duration: 5000,
           });
           handleToggleDisable(false);
+          handleIsOpen(null, false);
+          checkLogin();
           router.push("/");
         },
         onError: () => {
           toast({
-            title: "회원가입에 실패했습니다.",
+            title: "로그인에 실패했습니다.",
             variant: "error",
             size: "lg",
             duration: 5000,
@@ -57,10 +62,10 @@ const useSignUpForm = () => {
         },
       });
     },
-    [handleToggleDisable, mutate, router, toast],
+    [handleIsOpen, handleToggleDisable, mutate, router, toast],
   );
 
-  return { register, handleSubmit, errors, isDisabled, OnSubmit };
+  return { register, handleSubmit, errors, OnSubmit, isDisabled };
 };
 
-export default useSignUpForm;
+export default useLoginForm;

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -2,11 +2,17 @@
 import TanstackQueryProvider from "@/providers/TanstackQueryProvider";
 import { PropsWithChildren } from "react";
 import { ToastProvider } from "@/components/UI/Toast/context/Toast";
+import { ModalProvider } from "@/context/modalContext";
+import { AuthProvider } from "@/context/auth";
 
 function Providers({ children }: PropsWithChildren) {
   return (
     <TanstackQueryProvider>
-      <ToastProvider>{children}</ToastProvider>
+      <AuthProvider>
+        <ModalProvider>
+          <ToastProvider>{children}</ToastProvider>
+        </ModalProvider>
+      </AuthProvider>
     </TanstackQueryProvider>
   );
 }

--- a/src/validators/login.validator.ts
+++ b/src/validators/login.validator.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const LoginFormSchema = z.object({
+  email: z.string().email({ message: "올바른 이메일을 입력해주세요." }),
+  password: z
+    .string()
+    .min(6, "비밀번호는 최소 6자리 이상이어야 합니다.")
+    .max(100, "비밀번호는 100자리 이하이어야 합니다."),
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,10 +227,20 @@
   dependencies:
     "@tanstack/query-core" "5.32.1"
 
+"@types/cookie@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
+  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
+"@types/node@^16.10.2":
+  version "16.18.96"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.96.tgz#eb0012d23ff53d14d64ec8a352bf89792de6aade"
+  integrity sha512-84iSqGXoO+Ha16j8pRZ/L90vDMKX04QTYMTfYeE1WrjWaZXuchBehGUZEpNgx7JnmlrIHdnABmpjrQjhCnNldQ==
 
 "@types/node@^20":
   version "20.12.8"
@@ -662,6 +672,20 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+cookie@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
+  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
+
+cookies-next@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/cookies-next/-/cookies-next-4.1.1.tgz#54498efe867bb5c1a47b5a99a7ea8563601c2413"
+  integrity sha512-20QaN0iQSz87Os0BhNg9M71eM++gylT3N5szTlhq2rK6QvXn1FYGPB4eAgU4qFTunbQKhD35zfQ95ZWgzUy3Cg==
+  dependencies:
+    "@types/cookie" "^0.6.0"
+    "@types/node" "^16.10.2"
+    cookie "^0.6.0"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"


### PR DESCRIPTION
login & logout
- Login 기능 완료
 - api route를 통해 backend에서 전달받은 response의 헤더에 set-cookie를 cookie에 accessToken으로 저장
 - 페이지가 바뀔때마다 Token 체크
- Logout 기능 완료
 - api route를 통해 server에서 cookie 삭제